### PR TITLE
Do we still need module titles in collxml

### DIFF
--- a/collections/book-slug1.collection.xml
+++ b/collections/book-slug1.collection.xml
@@ -15,7 +15,7 @@
     <col:subcollection>
       <md:title>subcollection</md:title>
       <col:content>
-          <col:module document="m123" sys:version-at-this-collection-version="999.999"><md:title>We still needs titles in  the Collxml</md:title></col:module>
+          <col:module document="m123" sys:version-at-this-collection-version="999.999"/>
       </col:content>
     </col:subcollection>
   </col:content>


### PR DESCRIPTION
When a title tag is inside of a module tag in collxml, this is what would have been considered a `DocumentPointer` and the refactored version of Neb assemble does not support this syntax. I could not find a place where this occurs in any other book repositories. 